### PR TITLE
feat: allow github.com/... as well as https://github.com/...

### DIFF
--- a/src/gimmegit/_cli.py
+++ b/src/gimmegit/_cli.py
@@ -197,6 +197,8 @@ def get_context(args: argparse.Namespace) -> Context:
 def make_github_url(repo: str) -> str:
     if repo.startswith("https://github.com/"):
         return repo
+    if repo.startswith("github.com/"):
+        return f"https://{repo}"
     if repo.count("/") == 1 and not repo.endswith("/"):
         return f"https://github.com/{repo}"
     if repo.endswith("/") or repo.endswith("\\"):

--- a/tests/test_context_no_token.py
+++ b/tests/test_context_no_token.py
@@ -88,6 +88,27 @@ def test_repo_url(no_ssh, snapshot_name):
     assert _cli.get_context(args) == expected_context
 
 
+def test_repo_url_no_https(no_ssh, snapshot_name):
+    args = argparse.Namespace(
+        upstream_owner=None,
+        base_branch=None,
+        repo="github.com/dwilding/gimmegit",
+        new_branch=None,
+    )
+    expected_context = _cli.Context(
+        base_branch=None,
+        branch="snapshot0801",
+        clone_url="https://github.com/dwilding/gimmegit.git",
+        clone_dir=Path("gimmegit/dwilding-snapshot0801"),
+        create_branch=True,
+        owner="dwilding",
+        project="gimmegit",
+        upstream_owner=None,
+        upstream_url=None,
+    )
+    assert _cli.get_context(args) == expected_context
+
+
 def test_repo_url_branch(no_ssh):
     args = argparse.Namespace(
         upstream_owner=None,
@@ -114,6 +135,27 @@ def test_branch_url(no_ssh):
         upstream_owner=None,
         base_branch=None,
         repo="https://github.com/dwilding/gimmegit/tree/next-release",
+        new_branch=None,
+    )
+    expected_context = _cli.Context(
+        base_branch=None,
+        branch="next-release",
+        clone_url="https://github.com/dwilding/gimmegit.git",
+        clone_dir=Path("gimmegit/dwilding-next-release"),
+        create_branch=False,
+        owner="dwilding",
+        project="gimmegit",
+        upstream_owner=None,
+        upstream_url=None,
+    )
+    assert _cli.get_context(args) == expected_context
+
+
+def test_branch_url_no_https(no_ssh):
+    args = argparse.Namespace(
+        upstream_owner=None,
+        base_branch=None,
+        repo="github.com/dwilding/gimmegit/tree/next-release",
         new_branch=None,
     )
     expected_context = _cli.Context(


### PR DESCRIPTION
Currently, gimmegit only supports GitHub URLs that begin with `https://github.com/`. This PR allows GitHub URLs that being with `github.com/` too, for convenience when typing URLs by hand. I'll keep `https://` in URLs in the docs, to emphasize that URLs can be pasted directly from a browser.