### PR TITLE
feat: for new branches, automatically create a remote branch on first push

### DIFF
--- a/src/gimmegit/_cli.py
+++ b/src/gimmegit/_cli.py
@@ -288,6 +288,19 @@ def clone(context: Context, cloning_args: list[str]) -> None:
                 f"Checking out a new branch {format_branch(context.branch)} based on {format_branch(base_branch_full)}"
             )
             branch = cloned.create_head(context.branch, upstream.refs[context.base_branch])
+            # Ensure that on first push, a remote branch is created and set as the tracking branch.
+            # The remote branch will be created on origin (the default remote).
+            with cloned.config_writer() as config:
+                config.set_value(
+                    "push",
+                    "default",
+                    "current",
+                )
+                config.set_value(
+                    "push",
+                    "autoSetupRemote",
+                    "true",
+                )
         else:
             # Create a local branch that tracks the existing branch on origin.
             logger.info(
@@ -305,6 +318,18 @@ def clone(context: Context, cloning_args: list[str]) -> None:
                 f"Checking out a new branch {format_branch(context.branch)} based on {format_branch(base_branch_full)}"
             )
             branch = cloned.create_head(context.branch, origin.refs[context.base_branch])
+            # Ensure that on first push, a remote branch is created and set as the tracking branch.
+            with cloned.config_writer() as config:
+                config.set_value(
+                    "push",
+                    "default",
+                    "current",
+                )
+                config.set_value(
+                    "push",
+                    "autoSetupRemote",
+                    "true",
+                )
         else:
             # Create a local branch that tracks the existing branch.
             logger.info(


### PR DESCRIPTION
Currently, gimmegit doesn't create a remote branch when you create a local branch. So `git push` doesn't work:

```
$ git push
fatal: The current branch snapshot0830 has no upstream branch.
To push the current branch and set the remote as upstream, use

    git push --set-upstream origin snapshot0830

To have this happen automatically for branches without a tracking
upstream, see 'push.autoSetupRemote' in 'git help config'.
```

This PR configures cloned repos so that on first push:
- A remote branch is created (`push.default = current`)
- The remote branch is set as the tracking branch (`push.autoSetupRemote = true`)

Here's what `git push` looks like with this config:

```
$ git push
Enumerating objects: 4, done.
Counting objects: 100% (4/4), done.
Delta compression using up to 14 threads
Compressing objects: 100% (2/2), done.
Writing objects: 100% (3/3), 971 bytes | 971.00 KiB/s, done.
Total 3 (delta 1), reused 0 (delta 0), pack-reused 0
remote: Resolving deltas: 100% (1/1), completed with 1 local object.
remote: 
remote: Create a pull request for 'snapshot0830' on GitHub by visiting:
remote:      https://github.com/dwilding/jubilant/pull/new/snapshot0830
remote: 
To github.com:dwilding/jubilant.git
 * [new branch]      snapshot0830 -> snapshot0830
branch 'snapshot0830' set up to track 'origin/snapshot0830'.
```