### PR TITLE
docs: drop "remote" in the context of upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ The new branch is based on the upstream repo's main branch. (Technically, it's b
 gimmegit -b <upstream-base-branch> -u <upstream-owner> <owner>/<project> <new-branch>
 ```
 
-After working on the new branch for a while, you might want to merge remote changes from the upstream base branch. To merge remote changes, run `git update-branch` in the clone directory. `update-branch` is a git alias that gimmegit created.
+After working on the new branch for a while, you might want to merge changes from the upstream base branch. To merge changes from upstream, run `git update-branch` in the clone directory. `update-branch` is a git alias that gimmegit created.
 
 ### Example
 
@@ -172,7 +172,7 @@ cd operator/dwilding-update-docs
 
 # Start your work…
 
-# Merge remote changes from canonical:main
+# Merge changes from canonical:main
 git update-branch
 
 # Realize that you need to work on something else too…
@@ -187,7 +187,7 @@ cd operator/dwilding-backport-docs
 
 # Start your work…
 
-# Merge remote changes from canonical:2.23-maintenance
+# Merge changes from canonical:2.23-maintenance
 git update-branch
 ```
 
@@ -205,7 +205,7 @@ cd operator/dwilding-update-docs
 
 # Start your work…
 
-# Merge remote changes from canonical:main
+# Merge changes from canonical:main
 git update-branch
 
 # Realize that you need to work on something else too…
@@ -220,7 +220,7 @@ cd operator/dwilding-backport-docs
 
 # Start your work…
 
-# Merge remote changes from canonical:2.23-maintenance
+# Merge changes from canonical:2.23-maintenance
 git update-branch
 ```
 
@@ -243,7 +243,7 @@ cd operator/dwilding-fix-something
 # Work on the branch…
 ```
 
-After working on the branch for a while, you might want to merge remote changes from the upstream repo's main branch. To merge remote changes, run `git update-branch` in the clone directory. `update-branch` is a git alias that gimmegit created.
+After working on the branch for a while, you might want to merge changes from the upstream repo's main branch. To merge changes from upstream, run `git update-branch` in the clone directory. `update-branch` is a git alias that gimmegit created.
 
 If the branch wasn't based on the upstream repo's main branch, use `-b` to set the upstream base branch when cloning the repo. For example:
 
@@ -257,7 +257,7 @@ cd operator/dwilding-backport-fix
 
 # Work on the branch…
 
-# Merge remote changes from canonical:2.23-maintenance
+# Merge changes from canonical:2.23-maintenance
 git update-branch
 ```
 


### PR DESCRIPTION
While reviewing the README, I found "merge remote changes from the upstream repo's main branch" quite a mouthful. In the context of an upstream repo, I think it can be reasonably assumed that changes are coming from a remote. So I'm dropping "remote" in this context.