### PR TITLE
refactor: use git config variables in update-branch script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,11 @@ build-backend = "uv_build"
 
 [tool.ruff]
 line-length = 99
+
+[tool.ty.environment]
+# Help ty resolve local imports in our testing code.
+root = [
+    "./src",
+    "./tests/functional",
+    "./tests/unit"
+]

--- a/src/gimmegit/_cli.py
+++ b/src/gimmegit/_cli.py
@@ -341,18 +341,36 @@ def clone(context: Context, cloning_args: list[str]) -> None:
     with cloned.config_writer() as config:
         update_branch = "!" + " && ".join(
             [
-                f'echo "$ git checkout {branch}"',
-                f'git checkout "{branch}"',
-                f'echo "$ git fetch {base_remote} {context.base_branch}"',
-                f'git fetch "{base_remote}" "{context.base_branch}"',
-                f'echo "$ git merge {base_remote}/{context.base_branch}"',
-                f'git merge "{base_remote}/{context.base_branch}"',
+                "branch=$(git config --get gimmegit.branch)",
+                "base_remote=$(git config --get gimmegit.baseRemote)",
+                "base_branch=$(git config --get gimmegit.baseBranch)",
+                'echo \\"$ git checkout $branch\\"',
+                "git checkout $branch",
+                'echo \\"$ git fetch $base_remote $base_branch\\"',
+                "git fetch $base_remote $base_branch",
+                'echo \\"$ git merge $base_remote/$base_branch\\"',
+                "git merge $base_remote/$base_branch",
             ]
         )  # Not cross-platform!
         config.set_value(
             "alias",
             "update-branch",
             update_branch,
+        )
+        config.set_value(
+            "gimmegit",
+            "branch",
+            context.branch,
+        )
+        config.set_value(
+            "gimmegit",
+            "baseRemote",
+            base_remote,
+        )
+        config.set_value(
+            "gimmegit",
+            "baseBranch",
+            context.base_branch,
         )
 
 

--- a/tests/functional/helpers.py
+++ b/tests/functional/helpers.py
@@ -1,0 +1,23 @@
+import subprocess
+
+
+def get_branch(dir: str):
+    result = subprocess.run(
+        ["git", "branch", "--show-current"],
+        cwd=dir,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def get_config(dir: str, name: str):
+    result = subprocess.run(
+        ["git", "config", "--get", name],
+        cwd=dir,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()

--- a/tests/functional/test_clone.py
+++ b/tests/functional/test_clone.py
@@ -1,18 +1,9 @@
 import pathlib
 import subprocess
 
+import helpers
+
 tool_args = ["--color", "never", "--ssh", "never"]
-
-
-def get_branch(dir: str):
-    result = subprocess.run(
-        ["git", "branch", "--show-current"],
-        cwd=dir,
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    return result.stdout.strip()
 
 
 def test_operator_branch(test_dir, tool_cmd):
@@ -33,7 +24,10 @@ Cloned repo:
 {expected_dir}
 """
     assert result.stdout == expected_stdout
-    assert get_branch(expected_dir) == "2.23-maintenance"
+    assert helpers.get_branch(expected_dir) == "2.23-maintenance"
+    assert helpers.get_config(expected_dir, "gimmegit.branch") == "2.23-maintenance"
+    assert helpers.get_config(expected_dir, "gimmegit.baseRemote") == "origin"
+    assert helpers.get_config(expected_dir, "gimmegit.baseBranch") == "main"
 
 
 def test_fork_jubilant(test_dir, tool_cmd):
@@ -55,7 +49,10 @@ Cloned repo:
 {expected_dir}
 """
     assert result.stdout == expected_stdout
-    assert get_branch(expected_dir) == "my-feature"
+    assert helpers.get_branch(expected_dir) == "my-feature"
+    assert helpers.get_config(expected_dir, "gimmegit.branch") == "my-feature"
+    assert helpers.get_config(expected_dir, "gimmegit.baseRemote") == "upstream"
+    assert helpers.get_config(expected_dir, "gimmegit.baseBranch") == "main"
 
 
 def test_fork_jubilant_exists(test_dir, tool_cmd):

--- a/tests/functional/test_clone_token.py
+++ b/tests/functional/test_clone_token.py
@@ -4,18 +4,9 @@ import subprocess
 
 import pytest
 
+import helpers
+
 tool_args = ["--color", "never", "--ssh", "never"]
-
-
-def get_branch(dir: str):
-    result = subprocess.run(
-        ["git", "branch", "--show-current"],
-        cwd=dir,
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    return result.stdout.strip()
 
 
 @pytest.fixture()
@@ -46,4 +37,7 @@ Cloned repo:
 {expected_dir}
 """
     assert result.stdout == expected_stdout
-    assert get_branch(expected_dir) == "my-feature"
+    assert helpers.get_branch(expected_dir) == "my-feature"
+    assert helpers.get_config(expected_dir, "gimmegit.branch") == "my-feature"
+    assert helpers.get_config(expected_dir, "gimmegit.baseRemote") == "upstream"
+    assert helpers.get_config(expected_dir, "gimmegit.baseBranch") == "main"


### PR DESCRIPTION
This PR switches the `git update-branch` script to use config variables instead of hardcoded values. I don't expect the values to be changed by the user, but I want to have an easy way to determine the values for #12 later.