### PR TITLE
fix: show an error if unable to find/clone repo

### DIFF
--- a/src/gimmegit/_cli.py
+++ b/src/gimmegit/_cli.py
@@ -170,7 +170,6 @@ def get_context(args: argparse.Namespace) -> Context:
         upstream_owner = upstream.owner
         upstream_url = upstream.remote_url
         project = upstream.project
-
     # Decide whether to create a branch.
     create_branch = False
     if not branch:

--- a/src/gimmegit/_cli.py
+++ b/src/gimmegit/_cli.py
@@ -158,19 +158,20 @@ def get_context(args: argparse.Namespace) -> Context:
     owner = parsed.owner
     project = parsed.project
     branch = parsed.branch
-    # Get clone URLs for origin and upstream.
     clone_url = make_github_clone_url(owner, project)
+    # Check that the repo exists and set the upstream repo.
+    upstream = get_github_upstream(owner, project)
+    # TOOD: Handle errors.
     upstream_owner = None
     upstream_url = None
     if args.upstream_owner:
         upstream_owner = args.upstream_owner
         upstream_url = make_github_clone_url(args.upstream_owner, project)
-    else:
-        upstream = get_github_upstream(owner, project)
-        if upstream:
-            upstream_owner = upstream.owner
-            upstream_url = upstream.remote_url
-            project = upstream.project
+    elif upstream:
+        upstream_owner = upstream.owner
+        upstream_url = upstream.remote_url
+        project = upstream.project
+
     # Decide whether to create a branch.
     create_branch = False
     if not branch:
@@ -269,7 +270,7 @@ def make_clone_path(owner: str, project: str, branch: str) -> Path:
 
 
 def clone(context: Context, cloning_args: list[str]) -> None:
-    # TODO: Handle branch errors
+    # TODO: Handle branch errors.
     logger.info(f"Cloning {context.clone_url}")
     cloned = git.Repo.clone_from(context.clone_url, context.clone_dir, multi_options=cloning_args)
     origin = cloned.remotes.origin

--- a/src/gimmegit/_cli.py
+++ b/src/gimmegit/_cli.py
@@ -96,7 +96,7 @@ def main() -> None:
     except git.GitCommandError:
         if SSH:
             logger.error(
-                "Unable to clone repo. Are you allowed to clone the repo? Is SSH correctly configured?"
+                "Unable to clone repo. Do you have access to the repo? Is SSH correctly configured?"
             )
         else:
             logger.error(
@@ -253,7 +253,7 @@ def get_github_upstream(owner: str, project: str) -> Upstream | None:
     try:
         repo = api.get_repo(f"{owner}/{project}")
     except github.UnknownObjectException:
-        raise ValueError(f"'{owner}/{project}' does not exist on GitHub.")
+        raise ValueError(f"Unable to find '{owner}/{project}' on GitHub. Do you have access to the repo?")
     if repo.fork:
         parent = repo.parent
         return Upstream(

--- a/src/gimmegit/_cli.py
+++ b/src/gimmegit/_cli.py
@@ -253,7 +253,9 @@ def get_github_upstream(owner: str, project: str) -> Upstream | None:
     try:
         repo = api.get_repo(f"{owner}/{project}")
     except github.UnknownObjectException:
-        raise ValueError(f"Unable to find '{owner}/{project}' on GitHub. Do you have access to the repo?")
+        raise ValueError(
+            f"Unable to find '{owner}/{project}' on GitHub. Do you have access to the repo?"
+        )
     if repo.fork:
         parent = repo.parent
         return Upstream(

--- a/src/gimmegit/_cli.py
+++ b/src/gimmegit/_cli.py
@@ -159,7 +159,7 @@ def get_context(args: argparse.Namespace) -> Context:
     project = parsed.project
     branch = parsed.branch
     clone_url = make_github_clone_url(owner, project)
-    # Check that the repo exists and set the upstream repo.
+    # Check that the repo exists and look for an upstream repo (if a token is set).
     upstream = get_github_upstream(owner, project)
     upstream_owner = None
     upstream_url = None

--- a/src/gimmegit/_cli.py
+++ b/src/gimmegit/_cli.py
@@ -91,7 +91,18 @@ def main() -> None:
         outcome = "You already have a clone:"
         logger.info(f"{format_outcome(outcome)}\n{context.clone_dir.resolve()}")
         sys.exit(10)
-    clone(context, cloning_args)
+    try:
+        clone(context, cloning_args)
+    except git.GitCommandError:
+        if SSH:
+            logger.error(
+                "Unable to clone repo. Are you allowed to clone the repo? Is SSH correctly configured?"
+            )
+        else:
+            logger.error(
+                "Unable to clone repo. Is the repo private? Try configuring Git to use SSH."
+            )
+        sys.exit(1)
     if not args.no_pre_commit:
         install_pre_commit(context.clone_dir)
     outcome = "Cloned repo:"

--- a/src/gimmegit/_cli.py
+++ b/src/gimmegit/_cli.py
@@ -161,7 +161,6 @@ def get_context(args: argparse.Namespace) -> Context:
     clone_url = make_github_clone_url(owner, project)
     # Check that the repo exists and set the upstream repo.
     upstream = get_github_upstream(owner, project)
-    # TOOD: Handle errors.
     upstream_owner = None
     upstream_url = None
     if args.upstream_owner:
@@ -241,7 +240,10 @@ def get_github_upstream(owner: str, project: str) -> Upstream | None:
     if not GITHUB_TOKEN:
         return None
     api = github.Github(GITHUB_TOKEN)
-    repo = api.get_repo(f"{owner}/{project}")
+    try:
+        repo = api.get_repo(f"{owner}/{project}")
+    except github.UnknownObjectException:
+        raise ValueError(f"'{owner}/{project}' does not exist on GitHub.")
     if repo.fork:
         parent = repo.parent
         return Upstream(

--- a/tests/functional/test_clone_token.py
+++ b/tests/functional/test_clone_token.py
@@ -60,4 +60,4 @@ Getting repo details
 Error: 'dwilding/invalid' does not exist on GitHub.
 """
     assert result.stderr == expected_stderr
-    assert not (pathlib.Path(test_dir) / "dwilding/invalid").exists()
+    assert not (pathlib.Path(test_dir) / "invalid").exists()

--- a/tests/functional/test_clone_token.py
+++ b/tests/functional/test_clone_token.py
@@ -57,7 +57,7 @@ Getting repo details
 """
     assert result.stdout == expected_stdout
     expected_stderr = """\
-Error: 'dwilding/invalid' does not exist on GitHub.
+Error: Unable to find 'dwilding/invalid' on GitHub. Do you have access to the repo?
 """
     assert result.stderr == expected_stderr
     assert not (pathlib.Path(test_dir) / "invalid").exists()

--- a/tests/functional/test_clone_token.py
+++ b/tests/functional/test_clone_token.py
@@ -41,3 +41,14 @@ Cloned repo:
     assert helpers.get_config(expected_dir, "gimmegit.branch") == "my-feature"
     assert helpers.get_config(expected_dir, "gimmegit.baseRemote") == "upstream"
     assert helpers.get_config(expected_dir, "gimmegit.baseBranch") == "main"
+
+
+@pytest.mark.skipif("GITHUB_TOKEN" not in os.environ, reason="GITHUB_TOKEN is not set")
+def test_invalid_repo_token(test_dir, tool_cmd, token_env):
+    result = subprocess.run(
+        tool_cmd + tool_args + ["invalid"],
+        env=token_env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )

--- a/tests/functional/test_clone_token.py
+++ b/tests/functional/test_clone_token.py
@@ -50,5 +50,14 @@ def test_invalid_repo_token(test_dir, tool_cmd, token_env):
         env=token_env,
         capture_output=True,
         text=True,
-        check=True,
     )
+    assert result.returncode == 1
+    expected_stdout = """\
+Getting repo details
+"""
+    assert result.stdout == expected_stdout
+    expected_stderr = """\
+Error: 'dwilding/invalid' does not exist on GitHub.
+"""
+    assert result.stderr == expected_stderr
+    assert not (pathlib.Path(test_dir) / "dwilding/invalid").exists()


### PR DESCRIPTION
Fixes #8. This PR handles the following conditions and shows an appropriate error message instead of crashing:

- When getting the repo details, if the repo can't be found. Only applies if a GitHub token is set.
- When cloning a repo, if the repo can't be cloned.