### PR TITLE
docs: improve project intro and description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
 # gimmegit
 
-> [!WARNING]  
-> gimmegit is in early development. Expect bugs and breaking changes!
+gimmegit is a command-line tool for cloning GitHub repos and creating branches.
 
-gimmegit is a command-line tool for cloning GitHub repos and creating branches. Each time you clone a repo, gimmegit creates a dedicated directory for the clone, based on the repo owner and branch name. For example:
+Each time you clone a repo, gimmegit creates a dedicated directory for the clone, based on the repo owner and branch name. For example, my clones of my [Frogtab](https://github.com/dwilding/frogtab) project might be organized like this:
 
 ```text
 .
 └── frogtab
-   ├── dwilding-my-feature  ← A clone of dwilding/frogtab, on a newly-created branch.
-   │   │                      Created by:
-   │   │                        gimmegit dwilding/frogtab my-feature
+   ├── dwilding-my-feature ← A clone of dwilding/frogtab, on a new branch. Created with:
+   │   │                       gimmegit dwilding/frogtab my-feature
    │   ├── ...
    │
-   └── <buddy>-their-branch ← A clone of <buddy>'s fork of frogtab, on their feature branch.
-       │                      Created by:
-       │                        gimmegit https://github.com/<buddy>/frogtab/tree/their-branch
+   └── <buddy>-custom-feat ← A clone of <buddy>'s fork, on their feature branch. Created with:
+       │                       gimmegit https://github.com/<buddy>/frogtab/tree/custom-feat
        ├── ...
 ```
+
+> [!WARNING]  
+> gimmegit is in early development. Expect bugs and breaking changes!
 
 You might find gimmegit interesting if:
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,23 @@
 > [!WARNING]  
 > gimmegit is in early development. Expect bugs and breaking changes!
 
-gimmegit is a command-line tool for cloning GitHub repos. You might find gimmegit interesting if:
+gimmegit is a command-line tool for cloning GitHub repos and creating branches. Each time you clone a repo, gimmegit creates a dedicated directory for the clone, based on the repo owner and branch name. For example:
+
+```text
+.
+└── frogtab
+   ├── dwilding-my-feature  ← A clone of dwilding/frogtab, on a newly-created branch.
+   │   │                      Created by:
+   │   │                        gimmegit dwilding/frogtab my-feature
+   │   ├── ...
+   │
+   └── <buddy>-their-branch ← A clone of <buddy>'s fork of frogtab, on their feature branch.
+       │                      Created by:
+       │                        gimmegit https://github.com/<buddy>/frogtab/tree/their-branch
+       ├── ...
+```
+
+You might find gimmegit interesting if:
 
   - You want several branches of the same repo checked out in parallel (as with [git-worktree](https://git-scm.com/docs/git-worktree))
   - You often review branches for other contributors

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 gimmegit is a command-line tool for cloning GitHub repos and creating branches.
 
+> [!WARNING]  
+> gimmegit is in early development. Expect bugs and breaking changes!
+
+You might find gimmegit interesting if:
+
+  - You want several branches of the same repo checked out in parallel (as with [git-worktree](https://git-scm.com/docs/git-worktree))
+  - You often review branches for other contributors
+  - You often work within forks of upstream repos
+
 Each time you clone a repo, gimmegit creates a dedicated directory for the clone, based on the repo owner and branch name. For example, my clones of [Frogtab](https://github.com/dwilding/frogtab) might be organized like this:
 
 ```text
@@ -15,15 +24,6 @@ Each time you clone a repo, gimmegit creates a dedicated directory for the clone
        │                       gimmegit https://github.com/<buddy>/frogtab/tree/custom-feat
        ├── ...
 ```
-
-> [!WARNING]  
-> gimmegit is in early development. Expect bugs and breaking changes!
-
-You might find gimmegit interesting if:
-
-  - You want several branches of the same repo checked out in parallel (as with [git-worktree](https://git-scm.com/docs/git-worktree))
-  - You often review branches for other contributors
-  - You often work within forks of upstream repos
 
 **Demo**
 

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ Each time you clone a repo, gimmegit creates a dedicated directory for the clone
 ```text
 .
 └── frogtab
-   ├── dwilding-my-feature ◀─ A clone of dwilding/frogtab, on a new branch. Created with
-   │   │                        gimmegit dwilding/frogtab my-feature
+   ├── dwilding-my-feature   A clone of dwilding/frogtab, on a new branch. Created with
+   │   │                       gimmegit dwilding/frogtab my-feature
    │   ├── ...
    │
-   └── <buddy>-custom-feat ◀─ A clone of <buddy>'s fork, on their feature branch. Created with
-       │                        gimmegit https://github.com/<buddy>/frogtab/tree/custom-feat
+   └── <buddy>-custom-feat   A clone of <buddy>'s fork, on their feature branch. Created with
+       │                       gimmegit https://github.com/<buddy>/frogtab/tree/custom-feat
        ├── ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Each time you clone a repo, gimmegit creates a dedicated directory for the clone
 ```text
 .
 └── frogtab
-   ├── dwilding-my-feature   A clone of dwilding/frogtab, on a new branch. Created with
+   ├── dwilding-my-feature   A clone of the Frogtab repo, on a new branch. Created with
    │   │                       gimmegit dwilding/frogtab my-feature
    │   ├── ...
    │

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ Each time you clone a repo, gimmegit creates a dedicated directory for the clone
 ```text
 .
 └── frogtab
-   ├── dwilding-my-feature ← A clone of dwilding/frogtab, on a new branch. Created with:
+   ├── dwilding-my-feature ◀ A clone of dwilding/frogtab, on a new branch. Created with:
    │   │                       gimmegit dwilding/frogtab my-feature
    │   ├── ...
    │
-   └── <buddy>-custom-feat ← A clone of <buddy>'s fork, on their feature branch. Created with:
+   └── <buddy>-custom-feat ◀ A clone of <buddy>'s fork, on their feature branch. Created with:
        │                       gimmegit https://github.com/<buddy>/frogtab/tree/custom-feat
        ├── ...
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# gimmegit
+# gimmegit — Isolated directories for Git branches
 
 gimmegit is a command-line tool for cloning GitHub repos and creating branches.
 

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ Each time you clone a repo, gimmegit creates a dedicated directory for the clone
 ```text
 .
 └── frogtab
-   ├── dwilding-my-feature ◀ A clone of dwilding/frogtab, on a new branch. Created with:
-   │   │                       gimmegit dwilding/frogtab my-feature
+   ├── dwilding-my-feature  ◀ A clone of dwilding/frogtab, on a new branch. Created with
+   │   │                        gimmegit dwilding/frogtab my-feature
    │   ├── ...
    │
-   └── <buddy>-custom-feat ◀ A clone of <buddy>'s fork, on their feature branch. Created with:
-       │                       gimmegit https://github.com/<buddy>/frogtab/tree/custom-feat
+   └── <buddy>-custom-feat  ◀ A clone of <buddy>'s fork, on their feature branch. Created with
+       │                        gimmegit https://github.com/<buddy>/frogtab/tree/custom-feat
        ├── ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ Each time you clone a repo, gimmegit creates a dedicated directory for the clone
 ```text
 .
 └── frogtab
-   ├── dwilding-my-feature  ◀ A clone of dwilding/frogtab, on a new branch. Created with
+   ├── dwilding-my-feature ◀─ A clone of dwilding/frogtab, on a new branch. Created with
    │   │                        gimmegit dwilding/frogtab my-feature
    │   ├── ...
    │
-   └── <buddy>-custom-feat  ◀ A clone of <buddy>'s fork, on their feature branch. Created with
+   └── <buddy>-custom-feat ◀─ A clone of <buddy>'s fork, on their feature branch. Created with
        │                        gimmegit https://github.com/<buddy>/frogtab/tree/custom-feat
        ├── ...
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 gimmegit is a command-line tool for cloning GitHub repos and creating branches.
 
-Each time you clone a repo, gimmegit creates a dedicated directory for the clone, based on the repo owner and branch name. For example, my clones of my [Frogtab](https://github.com/dwilding/frogtab) project might be organized like this:
+Each time you clone a repo, gimmegit creates a dedicated directory for the clone, based on the repo owner and branch name. For example, my clones of [Frogtab](https://github.com/dwilding/frogtab) might be organized like this:
 
 ```text
 .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "gimmegit"
 version = "0.0.16.dev0"
-description = "Create and clone fully-isolated branches"
+description = "A tool for cloning GitHub repos and creating branches."
 authors = [
     { name = "Dave Wilding", email = "tech@dpw.me" },
 ]

--- a/src/gimmegit/_cli.py
+++ b/src/gimmegit/_cli.py
@@ -50,7 +50,9 @@ class ParsedURL:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="A tool for cloning GitHub repos and creating branches.")
+    parser = argparse.ArgumentParser(
+        description="A tool for cloning GitHub repos and creating branches."
+    )
     parser.add_argument(
         "--color",
         choices=["auto", "always", "never"],

--- a/src/gimmegit/_cli.py
+++ b/src/gimmegit/_cli.py
@@ -50,7 +50,7 @@ class ParsedURL:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Create and clone fully-isolated branches")
+    parser = argparse.ArgumentParser(description="A tool for cloning GitHub repos and creating branches.")
     parser.add_argument(
         "--color",
         choices=["auto", "always", "never"],


### PR DESCRIPTION
This PR improves the intro to the README, mainly with a diagram that shows how clone directories might be organized. I've also made the description of the Python package & CLI tool a bit less cryptic.