### PR TITLE
feat!: exit with 11 if aborted cloning within a gimmegit clone

### DIFF
--- a/src/gimmegit/_cli.py
+++ b/src/gimmegit/_cli.py
@@ -126,7 +126,7 @@ def main() -> None:
                 configure_logger_info()
                 logger.info("")
                 status_usage(status)
-                return
+                sys.exit(11)  # Set a non-zero code because we didn't do what the user asked for.
         if not os.isatty(sys.stdout.fileno()) and not bool(os.getenv("GIMMEGIT_FORCE_STDOUT")):
             # GIMMEGIT_FORCE_STDOUT is intended for use in tests, not to be documented.
             set_global_info_to_stderr()
@@ -707,7 +707,7 @@ def primary_usage(args: argparse.Namespace, fetch_opts: list[str]) -> None:
         logger.info(context.clone_dir.resolve())
         if INFO_TO == "stderr":
             logger.log(DATA_LEVEL, context.clone_dir.resolve())
-        sys.exit(10)
+        sys.exit(10)  # Set a non-zero code because we didn't do what the user asked for.
     if (
         not args.allow_nested
         and context.clone_dir.parent.exists()

--- a/tests/functional/test_clone.py
+++ b/tests/functional/test_clone.py
@@ -266,8 +266,8 @@ def test_dashboard_warning(uv_run, test_dir):
         cwd=working_dir,
         capture_output=True,
         text=True,
-        check=True,
     )
+    assert result.returncode == 11
     expected_stdout = """\
 
 Project    Base branch      Review branch


### PR DESCRIPTION
Currently gimmegit exits with 0 if you try to clone within an existing gimmegit clone. In this case, gimmegit displays the status dashboard instead of cloning. The exit code is misleading because gimmegit didn't actually do what was asked, so I'm switching to code 11.