### PR TITLE
chore: add names to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,21 +11,25 @@ repos:
   - repo: local
     hooks:
       - id: just-lint
+        name: Run 'just lint'
         entry: just lint
         language: system
         pass_filenames: false
         always_run: true
       - id: just-unit
+        name: Run 'just unit'
         entry: just unit
         language: system
         pass_filenames: false
         always_run: true
       - id: just-zizmor
+        name: Run 'just zizmor'
         entry: just zizmor
         language: system
         pass_filenames: false
         always_run: true
       - id: just-command-ref
+        name: Run 'just command-ref'
         entry: just command-ref
         language: system
         pass_filenames: false


### PR DESCRIPTION
It turns out the names are required.