### PR TITLE
chore: manually manage Python dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,3 @@ updates:
       - "dependencies"
     cooldown:
       default-days: 7
-  - package-ecosystem: "uv"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    labels:
-      - "dependencies"
-    cooldown:
-      default-days: 7

--- a/.github/workflows/command-ref.yaml
+++ b/.github/workflows/command-ref.yaml
@@ -18,4 +18,4 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
       - name: Check the command reference
-        run: uvx --from rust-just just command-ref
+        run: uvx --from rust-just@1.52.0 just command-ref

--- a/.github/workflows/deps.yaml
+++ b/.github/workflows/deps.yaml
@@ -17,6 +17,5 @@ jobs:
           persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
-      - name: Install just
       - name: Check uv.lock and minimum version constraints
         run: uvx --from rust-just@1.52.0 just deps

--- a/.github/workflows/deps.yaml
+++ b/.github/workflows/deps.yaml
@@ -17,5 +17,6 @@ jobs:
           persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+      - name: Install just
       - name: Check uv.lock and minimum version constraints
-        run: uvx --from rust-just just deps
+        run: uvx --from rust-just@1.52.0 just deps

--- a/.github/workflows/functional-full.yaml
+++ b/.github/workflows/functional-full.yaml
@@ -29,4 +29,4 @@ jobs:
         env:
           UV_PYTHON: ${{ matrix.python-version }}
           GITHUB_TOKEN: ${{ secrets.DWILDING_GITHUB_TOKEN }}
-        run: uvx --from rust-just just functional
+        run: uvx --from rust-just@1.52.0 just functional

--- a/.github/workflows/functional-limited.yaml
+++ b/.github/workflows/functional-limited.yaml
@@ -17,4 +17,4 @@ jobs:
       - name: Run functional tests
         env:
           UV_PYTHON: '3.10'
-        run: uvx --from rust-just just functional
+        run: uvx --from rust-just@1.52.0 just functional

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,4 +18,4 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
       - name: Lint the code
-        run: uvx --from rust-just just lint
+        run: uvx --from rust-just@1.52.0 just lint

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -28,4 +28,4 @@ jobs:
       - name: Run unit tests
         env:
           UV_PYTHON: ${{ matrix.python-version }}
-        run: uvx --from rust-just just unit
+        run: uvx --from rust-just@1.52.0 just unit

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
       - name: Run zizmor
-        run: uvx --from rust-just just zizmor
+        run: uvx --from rust-just@1.52.0 just zizmor
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Avoid rate limits for zizmor's "online" checks.
       - name: Upload SARIF file

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -1,0 +1,16 @@
+Runtime dependencies:
+
+- [gitpython](https://github.com/gitpython-developers/GitPython/releases)
+- [pre-commit](https://github.com/pre-commit/pre-commit/releases)
+- [PyGithub](https://github.com/PyGithub/PyGithub/releases)
+    - [PyJWT](https://github.com/jpadilla/pyjwt/releases)
+    - [requests](https://github.com/psf/requests/releases)
+
+Development dependencies:
+
+- [ruff](https://github.com/astral-sh/ruff/releases)
+- [pytest](https://github.com/pytest-dev/pytest/releases)
+- [ty](https://github.com/astral-sh/ty/releases)
+- [zizmor](https://github.com/zizmorcore/zizmor/releases)
+- [uv_build](https://github.com/astral-sh/uv/releases)
+- [rust-just](https://github.com/gnpaone/rust-just/releases) (pinned in workflows)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 license = "MIT"
 license-files = ["LICENSE"]
-requires-python = ">= 3.10"
+requires-python = ">=3.10"
 dependencies = [
     "gitpython>=3.1.50,<4",
     "pre-commit>=4.6,<5",


### PR DESCRIPTION
I've decided to stop using dependabot for Python dependency updates. I don't find that dependabot saves effort, as it doesn't seem to bump minimum versions in `pyproject.toml` (I consider this important because I'm aiming for parity between `uv` and `pipx` installs).

Instead, I plan to manually manage dependency bumps. I've created `DEPENDENCIES.md` with links to the release notes for all my Python deps. This project is now stable, so the list should rarely change.

At each release, I'll review the latest version of each dep (applying a cooldown period) and see whether it's worth upgrading.

I'm retaining dependabot for security updates and GitHub actions.