### PR TITLE
feat!: rename --allow-nested to --nest

### DIFF
--- a/.github/workflows/pipx.yaml
+++ b/.github/workflows/pipx.yaml
@@ -21,7 +21,7 @@ jobs:
           package_dir="$PWD"
           mkdir -p demo
           cd demo
-          result="$(GIMMEGIT_FORCE_STDOUT=1 pipx run --spec "$package_dir" gimmegit --allow-nested -u canonical dwilding/jubilant my-feature)"
+          result="$(GIMMEGIT_FORCE_STDOUT=1 pipx run --spec "$package_dir" gimmegit --nest -u canonical dwilding/jubilant my-feature)"
           grep --quiet -F 'Installing pre-commit hook' <<< "$result"
           grep --quiet -F 'Cloned repo:' <<< "$result"
           grep --quiet -F '/jubilant/dwilding-my-feature' <<< "$result"

--- a/.github/workflows/uvx.yaml
+++ b/.github/workflows/uvx.yaml
@@ -23,7 +23,7 @@ jobs:
           package_dir="$PWD"
           mkdir -p demo
           cd demo
-          result="$(GIMMEGIT_FORCE_STDOUT=1 uvx --from "$package_dir" gimmegit --allow-nested -u canonical dwilding/jubilant my-feature)"
+          result="$(GIMMEGIT_FORCE_STDOUT=1 uvx --from "$package_dir" gimmegit --nest -u canonical dwilding/jubilant my-feature)"
           grep --quiet -F 'Installing pre-commit hook' <<< "$result"
           grep --quiet -F 'Cloned repo:' <<< "$result"
           grep --quiet -F '/jubilant/dwilding-my-feature' <<< "$result"

--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ To rebase instead of merge:
 
 --no-pre-commit                Don't try to install a pre-commit hook after cloning the repo.
 
---allow-nested                 Allow the clone directory to be inside a repo.
+--nest                         Allow the clone directory to be inside a repo.
 
 --force-project-dir            Create the project directory even if gimmegit finds a gimmegit
                                clone in the working directory.

--- a/justfile
+++ b/justfile
@@ -49,7 +49,7 @@ demo:
   mkdir -p demo
   cd demo
   rm -rf jubilant/dwilding-my-feature
-  uv run --project "$package_dir" gimmegit --allow-nested -u canonical dwilding/jubilant my-feature
+  uv run --project "$package_dir" gimmegit --nest -u canonical dwilding/jubilant my-feature
   cd jubilant/dwilding-my-feature
   echo
   uv run --project "$package_dir" gimmegit

--- a/src/gimmegit/_args.py
+++ b/src/gimmegit/_args.py
@@ -26,7 +26,7 @@ def parse_args(args_to_parse) -> ArgsWithUsage:
     parser.add_argument("--color", nargs="?")
     parser.add_argument("--ssh", nargs="?")
     parser.add_argument("--force-project-dir", action="store_true")
-    parser.add_argument("--allow-nested", action="store_true")
+    parser.add_argument("--nest", action="store_true")
     parser.add_argument("--no-pre-commit", action="store_true")
     parser.add_argument("-j", "--jumbo", action="store_true")
     parser.add_argument("-b", "--base-branch", nargs="?")
@@ -70,7 +70,7 @@ def parse_as_primary(args: argparse.Namespace, unknown_args: list[str]) -> ArgsW
         return done(MISSING_SSH)
     elif args.ssh not in CHOICES:
         return done(BAD_SSH)
-    # Handle --force-project-dir, --allow-nested, and --no-pre-commit.
+    # Handle --force-project-dir, --nest, and --no-pre-commit.
     if not hasattr(args, "force_project_dir"):
         args.force_project_dir = False
     if not hasattr(args, "allow_nested"):
@@ -167,7 +167,7 @@ def add_non_primary_unknown_args(args: argparse.Namespace, unknown_args: list[st
     if hasattr(args, "force_project_dir"):
         extended.append("--force-project-dir")
     if hasattr(args, "allow_nested"):
-        extended.append("--allow-nested")
+        extended.append("--nest")
     if hasattr(args, "no_pre_commit"):
         extended.append("--no-pre-commit")
     if hasattr(args, "jumbo"):

--- a/src/gimmegit/_args.py
+++ b/src/gimmegit/_args.py
@@ -73,8 +73,8 @@ def parse_as_primary(args: argparse.Namespace, unknown_args: list[str]) -> ArgsW
     # Handle --force-project-dir, --nest, and --no-pre-commit.
     if not hasattr(args, "force_project_dir"):
         args.force_project_dir = False
-    if not hasattr(args, "allow_nested"):
-        args.allow_nested = False
+    if not hasattr(args, "nest"):
+        args.nest = False
     if not hasattr(args, "no_pre_commit"):
         args.no_pre_commit = False
     # Handle -j/--jumbo.
@@ -166,7 +166,7 @@ def add_non_primary_unknown_args(args: argparse.Namespace, unknown_args: list[st
     extended = unknown_args.copy()
     if hasattr(args, "force_project_dir"):
         extended.append("--force-project-dir")
-    if hasattr(args, "allow_nested"):
+    if hasattr(args, "nest"):
         extended.append("--nest")
     if hasattr(args, "no_pre_commit"):
         extended.append("--no-pre-commit")

--- a/src/gimmegit/_cli.py
+++ b/src/gimmegit/_cli.py
@@ -103,7 +103,7 @@ def main() -> None:
     if hasattr(args, "ssh"):
         set_global_ssh(args.ssh)
     if args_with_usage.usage == "primary":
-        if not args.allow_nested:
+        if not args.nest:
             working = _inspect.get_outer_repo()
             if working:
                 status = _status.get_status(working)
@@ -671,7 +671,7 @@ def primary_usage(args: argparse.Namespace, fetch_opts: list[str]) -> None:
             logger.log(DATA_LEVEL, context.clone_dir.resolve())
         sys.exit(10)  # Set a non-zero code because we didn't do what the user asked for.
     if (
-        not args.allow_nested
+        not args.nest
         and context.clone_dir.parent.exists()
         and _inspect.get_repo(context.clone_dir.parent)
     ):

--- a/src/gimmegit/_help.py
+++ b/src/gimmegit/_help.py
@@ -66,7 +66,7 @@ To rebase instead of merge:
 
 --no-pre-commit                Don't try to install a pre-commit hook after cloning the repo.
 
---allow-nested                 Allow the clone directory to be inside a repo.
+--nest                         Allow the clone directory to be inside a repo.
 
 --force-project-dir            Create the project directory even if gimmegit finds a gimmegit
                                clone in the working directory.

--- a/tests/functional/test_arg_errors.py
+++ b/tests/functional/test_arg_errors.py
@@ -218,7 +218,7 @@ def test_status_unexpected(uv_run, test_dir):
         "--ssh",
         "always",
         "--force-project-dir",
-        "--allow-nested",
+        "--nest",
         "--no-pre-commit",
         "-j",
         "-b",
@@ -235,7 +235,7 @@ def test_status_unexpected(uv_run, test_dir):
     assert result.returncode == 2
     assert not result.stdout
     expected_stderr = """\
-Error: Unexpected options: --force-project-dir, --allow-nested, --no-pre-commit, -j/--jumbo, -b/--base-branch, -u/--upstream-owner, --ssh. Run 'gimmegit -h' for help.
+Error: Unexpected options: --force-project-dir, --nest, --no-pre-commit, -j/--jumbo, -b/--base-branch, -u/--upstream-owner, --ssh. Run 'gimmegit -h' for help.
 """
     assert result.stderr == expected_stderr
 

--- a/tests/functional/test_outer.py
+++ b/tests/functional/test_outer.py
@@ -87,7 +87,7 @@ Error: The working directory is inside a repo.
 def test_working_repo_allow(uv_run, test_dir):
     # .
     # └── frogtab           Suppose that this dir is a repo
-    #     └── foo           Try running 'gimmegit --allow-nested dwilding/frogtab my-feature'
+    #     └── foo           Try running 'gimmegit --nest dwilding/frogtab my-feature'
     #         └── frogtab   These dirs will be created
     #             └── dwilding-my-feature
     #
@@ -97,7 +97,7 @@ def test_working_repo_allow(uv_run, test_dir):
         *uv_run,
         "gimmegit",
         *helpers.no_ssh,
-        "--allow-nested",
+        "--nest",
         "dwilding/frogtab",
         "my-feature",
     ]
@@ -152,7 +152,7 @@ Error: '{project_dir}' is a repo.
 
 
 def test_project_repo_allow(uv_run, test_dir):
-    # .                             Try running 'gimmegit --allow-nested dwilding/frogtab my-feature'
+    # .                             Try running 'gimmegit --nest dwilding/frogtab my-feature'
     # └── frogtab                   Suppose that this dir is a repo
     #     └── dwilding-my-feature   This dir will be created
     #
@@ -162,7 +162,7 @@ def test_project_repo_allow(uv_run, test_dir):
         *uv_run,
         "gimmegit",
         *helpers.no_ssh,
-        "--allow-nested",
+        "--nest",
         "dwilding/frogtab",
         "my-feature",
     ]

--- a/tests/functional/test_outer_clone.py
+++ b/tests/functional/test_outer_clone.py
@@ -30,7 +30,7 @@ def test_working_clone_exclude_dotgit(uv_run, test_dir):
         *uv_run,
         "gimmegit",
         *helpers.no_ssh,
-        "--allow-nested",
+        "--nest",
         "dwilding/frogtab",
         "inner",
     ]


### PR DESCRIPTION
I find myself typing `--allow-nested` quite frequently (when I want to pull in a related repo for reference while working on another repo). Renaming the option to be more finger friendly.