### PR TITLE
chore: remove ty environment config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,12 +39,3 @@ exclude-newer = "7 days"
 
 [tool.ruff]
 line-length = 99
-
-[tool.ty.environment]
-# Help ty resolve local imports in our testing code.
-root = [
-    "./src",
-    "./tests/functional",
-    "./tests/stress",
-    "./tests/unit",
-]


### PR DESCRIPTION
Recent versions of ty don't need this config.